### PR TITLE
Add manual GitHub Action for PDF rendering

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,40 @@
+# GitHub Actions Workflows
+
+## Render Book PDF
+
+**File:** `render-book-pdf.yml`
+
+**Purpose:** Manually trigger a book PDF render and download the result.
+
+**How to use:**
+
+1. Go to the [Actions tab](../../actions/workflows/render-book-pdf.yml) in GitHub
+2. Click "Run workflow" button
+3. Select the branch you want to render from
+4. Click the green "Run workflow" button
+5. Wait for the workflow to complete (~10-20 minutes)
+6. Download the PDF from the "Artifacts" section at the bottom of the workflow run page
+
+**What it does:**
+
+- Sets up Python 3.11 and all dependencies (uv, Graphviz, Jupyter kernel)
+- Installs Quarto and TinyTeX (LaTeX)
+- Runs `python scripts/render-book-pdf.py` to generate the PDF
+- Uploads the PDF as a downloadable artifact named `war-on-disease-book-pdf`
+- Artifact is kept for 30 days
+
+**Output:**
+
+- Artifact name: `war-on-disease-book-pdf`
+- Contains: `*.pdf` files from `_book/warondisease/` directory
+
+## Other Workflows
+
+### `publish.yml`
+Main publishing workflow for deploying to GitHub Pages.
+
+### `build-pdf-only.yml`
+Low-level PDF build for local testing with `act`.
+
+### `claude-assistant.yml`
+Claude Code automation workflow.

--- a/.github/workflows/render-book-pdf.yml
+++ b/.github/workflows/render-book-pdf.yml
@@ -1,0 +1,82 @@
+name: Render Book PDF
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  render-book-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Cache Quarto freeze
+        uses: actions/cache@v4
+        with:
+          path: _freeze
+          key: quarto-freeze-${{ hashFiles('**/*.qmd', '**/*.ipynb') }}
+          restore-keys: |
+            quarto-freeze-
+
+      - name: Install Quarto
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y wget
+          curl -LO https://quarto.org/download/latest/quarto-linux-amd64.deb
+          if [ -f quarto-linux-amd64.deb ]; then
+            sudo dpkg -i quarto-linux-amd64.deb || sudo apt-get install -f -y
+            rm -f quarto-linux-amd64.deb
+            quarto --version
+          else
+            echo "ERROR: Failed to download Quarto"
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y graphviz
+
+      - name: Install Python dependencies
+        run: uv pip install --system -r requirements.txt
+
+      - name: Install Jupyter kernel
+        run: |
+          python -m ipykernel install --user --name dih-project-kernel --display-name "DIH Project"
+
+      - name: Install LaTeX
+        run: quarto install tinytex
+
+      - name: Render Book PDF
+        run: python scripts/render-book-pdf.py
+        timeout-minutes: 20
+
+      - name: Upload Book PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: war-on-disease-book-pdf
+          path: '_book/warondisease/*.pdf'
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: List generated files
+        if: always()
+        run: |
+          echo "Contents of _book directory:"
+          ls -lah _book/ || echo "No _book directory"
+          echo ""
+          echo "Contents of _book/warondisease directory:"
+          ls -lah _book/warondisease/ || echo "No _book/warondisease directory"


### PR DESCRIPTION
- New workflow: render-book-pdf.yml for on-demand PDF generation
- Uses render-book-pdf.py script (proper high-level book rendering)
- Uploads PDF as downloadable artifact (30-day retention)
- Add workflow documentation in .github/workflows/README.md

This allows maintainers to manually trigger PDF builds and download the result without running the full publish workflow.

### Description of Change

_A clear and concise description of the changes. What was added, removed, or updated? Why is this change necessary?_

Fixes # (issue)

---

### Wiki Contributor Checklist

_Before submitting, please verify that you have completed the following:_

- [ ] **Read the Manual:** I have read and followed all guidelines in the root [**CONTRIBUTING.md**](../CONTRIBUTING.md).
- [ ] **Voice & Tone:** The content adheres to the project's direct and concise writing style.
- [ ] **Citations:** All new factual claims, statistics, or figures are cited using the mandatory [anchor-based citation method](../CONTRIBUTING.md#4-sourcing-and-citation-standard-critical).
- [ ] **Information Architecture:** The file(s) are placed in the correct top-level directory per the [guidelines](../CONTRIBUTING.md#1-information-architecture-what-goes-where).
- [ ] **Frontmatter:** All files include a complete and accurate YAML frontmatter block per the [standard](../CONTRIBUTING.md#2-frontmatter-requirements).
- [ ] **Internal Links:** All references to other documents in this wiki are standard [relative Markdown links](../CONTRIBUTING.md#5-naming-linking-and-formatting).
- [ ] **Self-Review:** I have performed a self-review of my changes to check for typos, grammatical errors, and clarity.
